### PR TITLE
Extend inventory configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,15 @@
 *Small suite of playbooks intended to help quickly spin up a test environment
 for other playbook work.*
 
+## Overview
+
+| Name               | Purpose (short)                                                      | Documentation                                                              |
+|--------------------|----------------------------------------------------------------------|----------------------------------------------------------------------------|
+| `site.yml`         | Call `lxd-setup.yml` and `docker-setup.yml`                         | [lxd-setup.yml](docs/lxd-setup.md), [docker-setup.yml](docs/docker-setup.md) |
+| `docker-setup.yml` | Install packages, configure specified hosts to run Docker containers | [playbook](docs/docker-setup.md)                                           |
+| `lxd-setup.yml`    | Create LXD container test environment                                | [playbook](docs/lxd-setup.md)                                              |
+| `lxd-remove.yml`   | Tear down LXD container test environment                             | [playbook](docs/lxd-remove.md)                                             |
+
 ## Limitations
 
 ### Linux Distributions
@@ -21,10 +30,10 @@ is incompatible with ZFS LXD storage, so it is a choice that you will have to
 intentionally opt-in to using.
 
 To set this value (or any other Docker storage driver), set the
-`lxd_containers_docker_storage_driver` variable within the `lxd-setup.yml`
-playbook or another file that you include from the playbook. As of this
-writing an override to enable use of the `overlay` driver is commented out
-in the appropriate place in the playbook.
+`lxd_containers_docker_storage_driver` variable within the
+[`lxd-setup.yml`](docs/lxd-setup.md) playbook or another file that you include
+from the playbook. As of this writing an override to enable use of the
+`overlay` driver is commented out in the appropriate place in the playbook.
 
 ## Prerequisites
 
@@ -63,38 +72,30 @@ sufficient.
 
 ### Install roles
 
-- While it is technically possible to install each role manually, a
-  `requirements.yml` file is provided to help automate this step.
-- Because `ansible-galaxy` does not yet natively support updating existing
-  roles, the example installation instructions provided below include the
-  `--force` parameter to *force* pulling in the latest updates as directed by
-  the `requirements.yml` file.
-
-#### Option 1: Within your home directory
-
-- `ansible-galaxy install -r requirements.yml --force`
-
-#### Option 2: Within a `roles` directory in the same location as playbooks
-
-- `ansible-galaxy install -r requirements.yml -p roles --force`
-
-#### Option 3: System-wide for all users
-
-- `sudo ansible-galaxy install -r requirements.yml --force`
+See the guide [here](docs/install-roles.md) for the steps needed to install
+roles required by these playbooks.
 
 ### Create new test environment
 
 The following steps will prep the host to run LXD containers and then proceed
-to spin up several CentOS and Ubuntu containers. By default at least one
-additional contain will be spun up as a Docker Host for testing Docker related
-playbooks. Edit `site.yml` and disable the inclusion of the `docker-setup.yml`
-playbook to disable that step:
+to spin up several CentOS and Ubuntu containers:
 
 - `ansible-playbook -i inventories/testing site.yml -K`
+
+Note: By default, at least one additional container will be spun up as a
+Docker Host for testing Docker related playbooks. Edit `site.yml` and disable
+the inclusion of the `docker-setup.yml` playbook to disable that step.
+
+See these docs for more information:
+
+- [lxd-setup.yml](docs/lxd-setup.md)
+- [docker-setup.yml](docs/docker-setup.md)
 
 ### Teardown test environment
 
 - `ansible-playbook -i inventories/testing lxd-remove.yml -K`
+
+See [this doc](docs/lxd-remove.md) for more information.
 
 ## References
 

--- a/docker-setup.yml
+++ b/docker-setup.yml
@@ -13,7 +13,11 @@
 
 - name: Configure Docker host
   hosts: docker-hosts
-  connection: local
+
+  # Rely on this setting to be specified in host_vars or group_vars files. If
+  # we lock in the 'local' option here then that rules out setting up any
+  # remote hosts as Docker hosts.
+  # connection: local
 
   # Should be fine to gather facts for just the  Docker host
   gather_facts: yes

--- a/docs/docker-setup.md
+++ b/docs/docker-setup.md
@@ -1,0 +1,31 @@
+# Ansible Playbook: docker-setup.yml
+
+## Overview
+
+Small playbook that uses the `atc0005.docker-host` role to install Docker
+related packages (APT, pip) for managing and running Docker containers. That
+role is often paired with the [`lxd-setup.yml`](lxd-setup.md) playbook for
+installing Docker within LXD containers for isolated testing.
+
+## Limitations
+
+- The `atc0005.docker-host` role (as of v1.0) is only compatible with Ubuntu,
+  therefore this playbook is only compatible with Ubuntu.
+
+## Requirements
+
+1. Move into directory containing inventories and playbooks dir
+1. Install required roles
+    - `ansible-galaxy install -r requirements.yml -p roles --force`
+
+## Usage
+
+Run playbook against relevant inventory. In this case, we target our
+testing inventory from the main directory:
+
+`ansible-playbook -i inventories/testing docker-setup.yml -K`
+
+## References
+
+- <https://github.com/atc0005/ansible-role-docker-host>
+- <https://github.com/atc0005/ansible-role-docker-host/blob/v1.0/README.md>

--- a/docs/install-roles.md
+++ b/docs/install-roles.md
@@ -1,0 +1,30 @@
+# Ansible Playbook: lxd-testenv
+
+## Install roles needed for playbook use
+
+- While it is technically possible to install each role manually, a
+  `requirements.yml` file is provided to help automate this step.
+- Because `ansible-galaxy` does not yet natively support updating existing
+  roles, the example installation instructions provided below include the
+  `--force` parameter to *force* pulling in the latest updates as directed by
+  the `requirements.yml` file.
+
+### Option 1: Within your home directory
+
+- `ansible-galaxy install -r requirements.yml --force`
+
+### Option 2: Within a `roles` directory in the same location as playbooks
+
+- `ansible-galaxy install -r requirements.yml -p roles --force`
+
+### Option 3: System-wide for all users
+
+- `sudo ansible-galaxy install -r requirements.yml --force`
+
+## See also
+
+- Main [README](../README.md) file
+
+- <https://github.com/atc0005/ansible-role-lxd-host>
+- <https://github.com/atc0005/ansible-role-lxd-testenv>
+- <https://github.com/atc0005/ansible-role-docker-host>

--- a/docs/lxd-remove.md
+++ b/docs/lxd-remove.md
@@ -1,0 +1,35 @@
+# Ansible Playbook: lxd-remove.yml
+
+## Overview
+
+Small playbook that uses the `atc0005.lxd-testenv` role to tear down or remove
+a LXD-based testing environment previously created by running the
+[`lxd-setup.yml`](lxd-setup.md) playbook.
+
+## Limitations
+
+- This playbook relies upon the `atc0005.lxd-testenv` role and as of v1.0 that
+  role is only compatible with Ubuntu. Because of this, this playbook is only
+  compatible with Ubuntu.
+
+## Requirements
+
+1. Move into directory containing inventories and playbooks dir
+1. Install required roles
+    - `ansible-galaxy install -r requirements.yml -p roles --force`
+
+## Usage
+
+Run playbook against relevant inventory. In this case, we target our
+testing inventory from the main directory:
+
+`ansible-playbook -i inventories/testing lxd-remove.yml -K`
+
+## Playbook runtime
+
+About 2-3 minutes when using a SSD drive.
+
+## References
+
+- <https://github.com/atc0005/ansible-playbook-lxd-testenv>
+- <https://github.com/atc0005/ansible-playbook-lxd-testenv/blob/master/README.md>

--- a/docs/lxd-setup.md
+++ b/docs/lxd-setup.md
@@ -1,0 +1,52 @@
+# Ansible Playbook: lxd-setup.yml
+
+## Overview
+
+Small playbook that uses the `atc0005.lxd-testenv` role to create a LXD-based
+testing environment. The [`lxd-remove.yml`](lxd-remove.md) playbook is
+intended to tear down the test environment as needed in order to refresh the
+environment.
+
+## Limitations
+
+- This playbook relies upon the `atc0005.lxd-testenv` role and as of v1.0 that
+  role is only compatible with Ubuntu. Because of this, this playbook is only
+  compatible with Ubuntu.
+
+- This playbook imports the `atc0005.lxd-host` role, but as of this writing
+  that role is not ready for actual use and only echoes a placeholder debug
+  statement.
+
+## Requirements
+
+### Install roles
+
+1. Move into directory containing inventories, and playbooks dir
+1. Install required roles
+    - `ansible-galaxy install -r requirements.yml -p roles --force`
+
+### Install LXD packages, perform initial configuration
+
+For now, see the `atc0005.lxd-testenv` role [README](#references) for the
+specific packages and steps needed to prepare an Ubuntu system to run LXD
+containers for local testing purposes.
+
+## Usage
+
+Run playbook against relevant inventory. In this case, we target our
+testing inventory from the main directory:
+
+`ansible-playbook -i inventories/testing lxd-setup.yml -K`
+
+## Playbook runtime
+
+This playbook takes on average around 12 minutes to run. This appears to be
+irregardless of whether you use LXD `dir` or `zfs` storage when backed by
+physical SSD storage.
+
+Have a cup of tea or coffee while you wait. :)
+
+## References
+
+- <https://github.com/atc0005/ansible-playbook-lxd-testenv>
+- <https://github.com/atc0005/ansible-playbook-lxd-testenv/blob/master/README.md>

--- a/inventories/testing/group_vars/all.yml
+++ b/inventories/testing/group_vars/all.yml
@@ -1,4 +1,5 @@
 ---
 
+# This file is for variables that apply to all hosts in this inventory.
 
 ...

--- a/inventories/testing/group_vars/centos.yml
+++ b/inventories/testing/group_vars/centos.yml
@@ -1,9 +1,10 @@
 ---
 
 # Defines what container image is used
-
 lxd_image_source: "centos/7/amd64"
 
+# Distro-specific command needed to install Python 2. Python is needed on the
+# host systems in order to provide access to additional modules.
 python_install_command: "yum install -y python"
 
 ...

--- a/inventories/testing/group_vars/lxd-all-containers.yml
+++ b/inventories/testing/group_vars/lxd-all-containers.yml
@@ -7,4 +7,9 @@ ansible_connection: "lxd"
 # lxd does not support remote_user (i.e., this setting) and defaults to 'root'
 ansible_user: "root"
 
+# Explictly set here instead of within playbooks that manipulate containers
+# created from this testing inventory. This allows those same playbooks
+# (at least in theory) to be used for truly remote hosts as well.
+connection: local
+
 ...

--- a/inventories/testing/group_vars/lxd-docker-containers.yml
+++ b/inventories/testing/group_vars/lxd-docker-containers.yml
@@ -1,7 +1,7 @@
 ---
 
-# Placeholder for settings specific to setting up a LXD container intended
-# to host a Docker daemon / test environment
+# Settings specific to LXD containers intended to host a Docker daemon / test
+# environment
 lxd_containers_profiles:
   - "default"
   - "docker"

--- a/inventories/testing/group_vars/lxd-hosts.yml
+++ b/inventories/testing/group_vars/lxd-hosts.yml
@@ -2,6 +2,8 @@
 
 # Allow the installation of LXD packages necessary to create and manage LXD
 # containers. Apply this setting only to host systems in the lxd_hosts group.
+# Note: As of v1.0 of the role and associated playbooks, this option does
+# nothing, though there are plans to implement it in the future.
 setup_lxd_host: true
 
 

--- a/inventories/testing/group_vars/ubuntu.yml
+++ b/inventories/testing/group_vars/ubuntu.yml
@@ -3,6 +3,8 @@
 # Defines what container image is used
 lxd_image_source: "ubuntu/xenial/amd64"
 
+# Distro-specific command needed to install Python 2. Python is needed on the
+# host systems in order to provide access to additional modules.
 python_install_command: "apt-get update && apt-get install -y python"
 
 ...

--- a/inventories/testing/host_vars/ansible-centos-1.yml
+++ b/inventories/testing/host_vars/ansible-centos-1.yml
@@ -1,0 +1,7 @@
+---
+
+
+# This file is for variables specific to the host of the same name as this
+# file (minus extension of course)
+
+...

--- a/inventories/testing/host_vars/ansible-centos-2.yml
+++ b/inventories/testing/host_vars/ansible-centos-2.yml
@@ -1,0 +1,7 @@
+---
+
+
+# This file is for variables specific to the host of the same name as this
+# file (minus extension of course)
+
+...

--- a/inventories/testing/host_vars/ansible-centos-3.yml
+++ b/inventories/testing/host_vars/ansible-centos-3.yml
@@ -1,0 +1,7 @@
+---
+
+
+# This file is for variables specific to the host of the same name as this
+# file (minus extension of course)
+
+...

--- a/inventories/testing/host_vars/ansible-centos-4.yml
+++ b/inventories/testing/host_vars/ansible-centos-4.yml
@@ -1,0 +1,7 @@
+---
+
+
+# This file is for variables specific to the host of the same name as this
+# file (minus extension of course)
+
+...

--- a/inventories/testing/host_vars/ansible-centos-5.yml
+++ b/inventories/testing/host_vars/ansible-centos-5.yml
@@ -1,0 +1,7 @@
+---
+
+
+# This file is for variables specific to the host of the same name as this
+# file (minus extension of course)
+
+...

--- a/inventories/testing/host_vars/ansible-ubuntu-1.yml
+++ b/inventories/testing/host_vars/ansible-ubuntu-1.yml
@@ -1,0 +1,7 @@
+---
+
+
+# This file is for variables specific to the host of the same name as this
+# file (minus extension of course)
+
+...

--- a/inventories/testing/host_vars/ansible-ubuntu-2.yml
+++ b/inventories/testing/host_vars/ansible-ubuntu-2.yml
@@ -1,0 +1,7 @@
+---
+
+
+# This file is for variables specific to the host of the same name as this
+# file (minus extension of course)
+
+...

--- a/inventories/testing/host_vars/ansible-ubuntu-3.yml
+++ b/inventories/testing/host_vars/ansible-ubuntu-3.yml
@@ -1,0 +1,7 @@
+---
+
+
+# This file is for variables specific to the host of the same name as this
+# file (minus extension of course)
+
+...

--- a/inventories/testing/host_vars/ansible-ubuntu-4.yml
+++ b/inventories/testing/host_vars/ansible-ubuntu-4.yml
@@ -1,0 +1,7 @@
+---
+
+
+# This file is for variables specific to the host of the same name as this
+# file (minus extension of course)
+
+...

--- a/inventories/testing/host_vars/ansible-ubuntu-5.yml
+++ b/inventories/testing/host_vars/ansible-ubuntu-5.yml
@@ -1,0 +1,7 @@
+---
+
+
+# This file is for variables specific to the host of the same name as this
+# file (minus extension of course)
+
+...

--- a/inventories/testing/host_vars/ansible-ubuntu-docker.yml
+++ b/inventories/testing/host_vars/ansible-ubuntu-docker.yml
@@ -1,0 +1,7 @@
+---
+
+
+# This file is for variables specific to the host of the same name as this
+# file (minus extension of course)
+
+...

--- a/lxd-remove.yml
+++ b/lxd-remove.yml
@@ -10,7 +10,12 @@
 
 - name: Tear down our LXD test environment
   hosts: all
-  connection: local
+
+  # Rely on this setting to be specified in host_vars or group_vars files. If
+  # we lock in the 'local' option here then that rules out connecting via SSH
+  # later, perhaps as a means of validating earlier playbook tasks.
+  # connection: local
+
   gather_facts: no
 
   # This is needed due to potential for multiple access attempts via modules

--- a/lxd-setup.yml
+++ b/lxd-setup.yml
@@ -6,7 +6,11 @@
 
 - name: Configure base LXD host
   hosts: localhost
-  connection: local
+
+  # Rely on this setting to be specified in host_vars or group_vars files. If
+  # we lock in the 'local' option here then that rules out setting up any
+  # remote hosts as Docker hosts.
+  # connection: local
 
   # Should be fine to gather facts for just the future LXD host
   gather_facts: yes
@@ -22,7 +26,11 @@
 
 - name: Setup LXD test environment
   hosts: all
-  connection: local
+
+  # Rely on this setting to be specified in host_vars or group_vars files. If
+  # we lock in the 'local' option here then that rules out connecting via SSH
+  # later, perhaps as a means of validating earlier playbook tasks.
+  # connection: local
 
   # This is needed due to potential for multiple access attempts via modules
   # that are not intended/designed for it. Without this setting occasional


### PR DESCRIPTION
- Add host_vars files per testing inventory host

- Add applicable group_vars doc comments

- Move 'connection: local' setting to lxd-all-containers.yml in order to "free" the playbooks from having to explicitly specify that setting. This should allow those same playbooks to be used for remote host work later if needed.

- Add additional documentation: main README, separate doc files per playbook.