### PR TITLE
Update playbooks, docs to reflect v1.1 role

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ for other playbook work.*
 | `lxd-setup.yml`    | Create LXD container test environment                                | [playbook](docs/lxd-setup.md)                                              |
 | `lxd-remove.yml`   | Tear down LXD container test environment                             | [playbook](docs/lxd-remove.md)                                             |
 
+See [lxd-timing](docs/lxd-timing.md) for *very* rough estimates on the time
+needed to spinup/teardown a test environment.
+
 ## Limitations
 
 ### Linux Distributions
@@ -21,25 +24,21 @@ roles may add support for additional distributions.
 
 ### Docker storage driver
 
-Some Docker storage options are currently incompatible with LXD containers. If
-you use ZFS storage with LXD, Docker (as of 18.09 CE) refuses to work if you
-try to use anything other than `vfs`. If you use `dir` LXD storage, then you
-have the option of using `vfs` (slower, set by default in v1.0 of the
-`atc0005.lxd-testenv` role) or `overlay`. The `overlay` Docker storage driver
-is incompatible with ZFS LXD storage, so it is a choice that you will have to
-intentionally opt-in to using.
+Some Docker storage options are currently incompatible with LXD containers.
+For the most stable results, stick with the default `vfs` Docker storage
+driver. While slower than other options, it works with LXD 'dir' and 'zfs'
+storage. For better performance, use the `overlay` Docker storage driver if
+your backing LXD filesystem supports it. As of this writing, the `overlay2`
+Docker storage driver is not supported with LXD LTS 2.0.x or 3.0.x.
 
-To set this value (or any other Docker storage driver), set the
-`lxd_containers_docker_storage_driver` variable within the
-[`lxd-setup.yml`](docs/lxd-setup.md) playbook or another file that you include
-from the playbook. As of this writing an override to enable use of the
-`overlay` driver is commented out in the appropriate place in the playbook.
+See the [Docker storage drivers](docs/docker-storage-drivers.md) doc for
+details.
 
 ## Prerequisites
 
 ### Inventory
 
-To effectively use this collection of `lxd-testenv` playbooks you will need to
+To effectively use this collection of `lxd-testenv` playbooks, you will need to
 make sure you configure a test inventory entirely separate from your main
 production or development environment. Roles used by this playbook do not
 have the required polish and lack sufficient testing to safely interact with
@@ -56,17 +55,71 @@ role is intended to handle these steps, but as of this writing is only a stub
 role. For now, install the `lxd` and `lxd-client` packages and then run `sudo
 lxd init` and follow the instructions.
 
-### LXD initial setup
+Note: Make sure to logout and then back in after completing the `lxd init`
+menu-driven setup process in order to properly apply the new group membership.
+Without this, the playbooks will be denied access to the LXD interface.
 
-Be sure to use NAT, DHCP and setup a bridge network device (NAT). Containers
-created and attached to this bridge will be reachable by the host (and each
-other), but will not be directly reachable by external systems. You will need
-to setup port forwarding rules *or* setup an external bridge for containers
-to be externally reachable. Additionally, you will need to reconfigure LXD
-to use the new bridge device.
+### LXD configuration
 
-For most (playbook) testing purposes, the NAT bridge will probably be
-sufficient.
+#### TL;DR
+
+1. Insert any block devices that you wish to use with either LVM or ZFS storage
+    - *you also have the option of going with `dir` LXD storage, though it is
+      not as efficient as either LVM or ZFS with storage usage*
+1. Run `sudo lxd init`
+1. Answer questions; strongly consider going with NAT and IPv4 for simplicity
+
+If you later find that you do not want the chosen settins, reconfigure LXD:
+
+1. Run `sudo dpkg-reconfigure -p medium lxd`
+1. Answer questions, providing the new settings as desired
+
+#### Networking: NAT bridge
+
+For most (playbook) testing purposes, **the NAT bridge will probably be
+sufficient**.
+
+A NAT bridge allows host-to-container and container-to-container connections
+which covers many quick/one-off test cases that these playbooks and roles are
+intended to support. Be sure to use NAT, DHCP and setup a bridge network
+device (NAT). Containers created and attached to this bridge will be reachable
+by the host (and each other), but will not be directly reachable by external
+systems. To work around this on a small scale, you can setup port forwarding
+rules.
+
+For advanced use cases, you will need to setup a bridge that permits external
+access to containers and then assign that profile to containers as needed.
+
+See the [LXD Network configuration](#lxd-network-configuration) section for
+various external guides that provide the necessary steps to accomplish this.
+
+#### Networking: External bridge
+
+If you wish to have external systems connect to LXD containers you will need
+to configure a non-NAT bridge and use that for your containers.
+
+Creating a separate non-NAT bridge can be done initially or after the initial
+`sudo lxd init` setup process has completed.
+
+- If setting up the bridge after the initial setup process, you will need to
+  either create a new LXD profile or update the existing one.
+  - If updating the existing profile, those changes will be applied
+    automatically to containers already using it.
+  - If setting up a new profile, you will need to apply or assign the new
+    profile () to have the networking changes and then creating and applying a
+    custom profile for containers that *should* be externally accessible
+- If setting up the bridge during the initial `sudo lxd init` process you
+  *should* be able to define all needed options during setup.
+  - You can also setup the bridge *before* running `sudo lxd init` and then
+    have LXD use the existing bridge. This will provide that bridge by default
+    to all newly created containers.
+
+As of playbook and `atc0005.lxd-testenv` role version 1.1, this playbook and
+associated role can assign specified LXD profiles to containers, but you will
+have to take care of creating the role(s) yourself.
+
+See the [LXD Network configuration](#lxd-network-configuration) section for
+various external guides that provide the necessary steps to accomplish this.
 
 ## Usage
 
@@ -74,6 +127,22 @@ sufficient.
 
 See the guide [here](docs/install-roles.md) for the steps needed to install
 roles required by these playbooks.
+
+### Customize playbook variables
+
+Each of the following playbooks have common active and inactive settings
+configured which are intended to allow easy override of the base settings
+defined within the `defaults/main.yml` file included within the
+`atc0005.lxd-testenv` role.
+
+See these docs for more information:
+
+- [lxd-setup](docs/lxd-setup.md)
+- [docker-setup](docs/docker-setup.md)
+
+Review those settings and tweak as needed. See also the [README](#references)
+for the `atc0005.lxd-testenv` role (listed as `ansible-role-lxd-testenv`) for
+additional information for each supported option.
 
 ### Create new test environment
 
@@ -83,13 +152,18 @@ to spin up several CentOS and Ubuntu containers:
 - `ansible-playbook -i inventories/testing site.yml -K`
 
 Note: By default, at least one additional container will be spun up as a
-Docker Host for testing Docker related playbooks. Edit `site.yml` and disable
-the inclusion of the `docker-setup.yml` playbook to disable that step.
+Docker Host for testing Docker related playbooks. To disable this behavior,
+edit `inventories/testing/hosts` to remove the `ansible-ubuntu-docker` host
+entries and then modify the `site.yml` playbook to remove the inclusion of the
+`docker-setup.yml` playbook.
 
 See these docs for more information:
 
-- [lxd-setup.yml](docs/lxd-setup.md)
-- [docker-setup.yml](docs/docker-setup.md)
+- [lxd-setup](docs/lxd-setup.md)
+- [docker-setup](docs/docker-setup.md)
+
+See [lxd-timing](docs/lxd-timing.md) for *very* rough estimates on the time
+needed to spinup/teardown a test environment.
 
 ### Teardown test environment
 
@@ -97,13 +171,26 @@ See these docs for more information:
 
 See [this doc](docs/lxd-remove.md) for more information.
 
+See [lxd-timing](docs/lxd-timing.md) for *very* rough estimates on the time
+needed to spinup/teardown a test environment.
+
 ## References
 
 ### External
 
+#### General
+
 - [Generate /etc/hosts with Ansible](https://gist.github.com/rothgar/8793800)
 - <https://docs.ansible.com/ansible/latest/modules/lxd_container_module.html>
 - <https://stackoverflow.com/questions/30226113/ansible-ssh-prompt-known-hosts-issue>
+
+#### LXD Network configuration
+
+- <https://bayton.org/docs/linux/lxd/lxd-zfs-and-bridged-networking-on-ubuntu-16-04-lts/>
+- <https://blog.simos.info/how-to-make-your-lxd-containers-get-ip-addresses-from-your-lan-using-a-bridge/>
+- <https://discuss.linuxcontainers.org/t/how-to-create-a-non-nat-lxd-network-bridge-using-lxd-network/1547>
+- <https://www.technibble.com/forums/threads/start-using-containers-on-ubuntu.74887/>
+- <https://blog.ubuntu.com/2016/04/07/lxd-networking-lxdbr0-explained>
 
 ### Related repos
 

--- a/docs/docker-setup.md
+++ b/docs/docker-setup.md
@@ -28,4 +28,4 @@ testing inventory from the main directory:
 ## References
 
 - <https://github.com/atc0005/ansible-role-docker-host>
-- <https://github.com/atc0005/ansible-role-docker-host/blob/v1.0/README.md>
+- <https://github.com/atc0005/ansible-role-docker-host/blob/master/README.md>

--- a/docs/docker-storage-drivers.md
+++ b/docs/docker-storage-drivers.md
@@ -1,0 +1,52 @@
+# Ansible Role: Docker storage (docker-setup.yml)
+
+## LXD + Docker CE `overlay2` storage driver
+
+LXD 2.x or 3.x (regardless of LXD storage option) is incompatible with Docker
+Community Edition (CE) 18.09 with `overlay2` storage driver.
+
+Workaround:  Use `vfs` Docker storage, or if supported, `overlay` Docker
+storage.
+
+## LXD + ZFS storage + Docker CE `overlay` or `overlay` storage driver
+
+Docker storage drivers `overlay` and `overlay2` are not supported when using
+ZFS storage with LXD.
+
+Workaround: Use `vfs` Docker storage.
+
+## LXD + `dir` storage + Docker `overlay` storage driver
+
+LXD 2.0.x seems to be fine with this, but LXD 3.0.x with `dir` storage and
+Docker CE 18.09 with `overlay` storage driver causes the Docker daemon to fail
+to start.
+
+Workarounds:
+
+- Use `vfs` Docker storage
+- *or* set a LXD configuration option (either directly to the container or
+  within a LXD container profile) to load the required driver for use by the
+  container.
+
+## Docker `vfs` storage driver
+
+The `vfs` Docker storage driver is slow, but proved to be the most compatible
+during playbook/role testing. Unless you use ZFS storage for LXD, you should
+be able to use the `overlay` Docker storage driver. This can be set within the
+playbook in order to override the `atc0005.lxd-testenv` role default of using
+`vfs` Docker storage.
+
+To set this value (or any other Docker storage driver), set the
+`lxd_containers_docker_storage_driver` variable within the
+[`lxd-setup.yml`](lxd-setup.md) playbook or another file that you include
+from the playbook. As of this writing an override to enable use of the
+`overlay` driver is commented out in the appropriate place in the playbook.
+
+## References
+
+- See [the main README file](../README.md)
+- <https://github.com/atc0005/ansible-playbook-lxd-testenv>
+
+- <https://github.com/atc0005/ansible-role-lxd-host>
+- <https://github.com/atc0005/ansible-role-lxd-testenv>
+- <https://github.com/atc0005/ansible-role-docker-host>

--- a/docs/install-roles.md
+++ b/docs/install-roles.md
@@ -24,6 +24,7 @@
 ## See also
 
 - Main [README](../README.md) file
+- <https://github.com/atc0005/ansible-playbook-lxd-testenv>
 
 - <https://github.com/atc0005/ansible-role-lxd-host>
 - <https://github.com/atc0005/ansible-role-lxd-testenv>

--- a/docs/lxd-remove.md
+++ b/docs/lxd-remove.md
@@ -8,7 +8,7 @@ a LXD-based testing environment previously created by running the
 
 ## Limitations
 
-- This playbook relies upon the `atc0005.lxd-testenv` role and as of v1.0 that
+- This playbook relies upon the `atc0005.lxd-testenv` role and as of v1.1 that
   role is only compatible with Ubuntu. Because of this, this playbook is only
   compatible with Ubuntu.
 
@@ -27,7 +27,9 @@ testing inventory from the main directory:
 
 ## Playbook runtime
 
-About 2-3 minutes when using a SSD drive.
+Under a minute when using a SSD drive. Teardown time is nearly identical
+between using 'dir' and 'zfs' LXD storage. See the [lxd-timing](lxd-timing.md)
+doc for more details.
 
 ## References
 

--- a/docs/lxd-setup.md
+++ b/docs/lxd-setup.md
@@ -9,7 +9,7 @@ environment.
 
 ## Limitations
 
-- This playbook relies upon the `atc0005.lxd-testenv` role and as of v1.0 that
+- This playbook relies upon the `atc0005.lxd-testenv` role and as of v1.1 that
   role is only compatible with Ubuntu. Because of this, this playbook is only
   compatible with Ubuntu.
 
@@ -40,9 +40,10 @@ testing inventory from the main directory:
 
 ## Playbook runtime
 
-This playbook takes on average around 12 minutes to run. This appears to be
+This playbook takes on average around 8-10 minutes to run. This appears to be
 irregardless of whether you use LXD `dir` or `zfs` storage when backed by
-physical SSD storage.
+physical SSD storage. See the [lxd-timing](lxd-timing.md) doc for more
+details.
 
 Have a cup of tea or coffee while you wait. :)
 

--- a/docs/lxd-timing.md
+++ b/docs/lxd-timing.md
@@ -1,0 +1,83 @@
+# Ansible Role: LXD Test Environment (lxd-testenv)
+
+## Spinup and teardown "benchmarks"
+
+*I say benchmark only in the loosest sense.*
+
+### ZFS-based storage
+
+3.1 GB for images/containers (`/var/lib/lxd/`)
+
+#### Re-run of `site.yml`, no needed changes
+
+```ShellSession
+real	3m10.174s
+user	0m26.084s
+sys	0m8.208s
+```
+
+#### Removal of containers (`lxd-remove.yml`)
+
+```ShellSession
+real	0m40.381s
+user	0m5.460s
+sys	0m1.528s
+```
+
+#### Fresh `site.yml` run (complete setup)
+
+```ShellSession
+real	9m1.974s
+user	0m39.720s
+sys	0m11.784s
+```
+
+#### Fresh `lxd-setup.yml` run (partial setup)
+
+```ShellSession
+real	8m14.754s
+user	0m37.216s
+sys	0m11.300s
+```
+
+### dir based storage
+
+6.3 GB for images/containers (`/var/lib/lxd/`)
+
+#### Re-run of `site.yml`, no needed changes
+
+```ShellSession
+real	3m12.435s
+user	0m26.972s
+sys	0m9.652s
+```
+
+#### Removal of containers (`lxd-remove.yml`)
+
+```ShellSession
+real	0m40.351s
+user	0m5.460s
+sys	0m1.408s
+```
+
+#### Fresh `site.yml` run (complete setup)
+
+```ShellSession
+real	9m26.728s
+user	0m40.732s
+sys	0m12.344s
+```
+
+#### Fresh `lxd-setup.yml` run (partial setup)
+
+```ShellSession
+real	7m54.446s
+user	0m35.020s
+sys	0m10.744s
+```
+
+## References
+
+- <https://github.com/atc0005/ansible-playbook-lxd-testenv>
+- <https://github.com/atc0005/ansible-role-lxd-testenv>
+- <https://github.com/atc0005/ansible-role-lxd-testenv/issues/12>

--- a/inventories/testing/group_vars/lxd-docker-containers.yml
+++ b/inventories/testing/group_vars/lxd-docker-containers.yml
@@ -1,5 +1,12 @@
 ---
 
+# vim: ts=2:sw=2:et:ft=yaml
+# -*- mode: yaml; indent-tabs-mode: nil; tab-width: 2 -*-
+# code: language=yaml insertSpaces=true tabSize=2
+
+# https://github.com/atc0005/ansible-playbook-lxd-testenv
+# https://github.com/atc0005/ansible-role-lxd-testenv
+
 # Settings specific to LXD containers intended to host a Docker daemon / test
 # environment
 lxd_containers_profiles:

--- a/lxd-remove.yml
+++ b/lxd-remove.yml
@@ -4,24 +4,23 @@
 # -*- mode: yaml; indent-tabs-mode: nil; tab-width: 2 -*-
 # code: language=yaml insertSpaces=true tabSize=2
 
+# https://github.com/atc0005/ansible-playbook-lxd-testenv
+# https://github.com/atc0005/ansible-role-lxd-testenv
+
 # https://docs.ansible.com/ansible/latest/modules/lxd_container_module.html
 
 # Prune container settings after completion of test work
 
 - name: Tear down our LXD test environment
-  hosts: all
+  hosts: localhost
 
   # Rely on this setting to be specified in host_vars or group_vars files. If
   # we lock in the 'local' option here then that rules out connecting via SSH
   # later, perhaps as a means of validating earlier playbook tasks.
   # connection: local
 
+  # Fact gathering is not needed for container and settings removal
   gather_facts: no
-
-  # This is needed due to potential for multiple access attempts via modules
-  # that are not intended/designed for it. Without this setting occasional
-  # race conditions occur which results in data corruption.
-  serial: 1
 
   tasks:
 

--- a/lxd-setup.yml
+++ b/lxd-setup.yml
@@ -1,15 +1,18 @@
 ---
 
-# vim: ts=2:sw=2:et:ft=ansible
-# -*- mode: ansible; indent-tabs-mode: nil; tab-width: 2 -*-
-# code: language=ansible insertSpaces=true tabSize=2
+# vim: ts=2:sw=2:et:ft=yaml
+# -*- mode: yaml; indent-tabs-mode: nil; tab-width: 2 -*-
+# code: language=yaml insertSpaces=true tabSize=2
+
+# https://github.com/atc0005/ansible-playbook-lxd-testenv
+# https://github.com/atc0005/ansible-role-lxd-testenv
 
 - name: Configure base LXD host
   hosts: localhost
 
   # Rely on this setting to be specified in host_vars or group_vars files. If
   # we lock in the 'local' option here then that rules out setting up any
-  # remote hosts as Docker hosts.
+  # remote hosts as LXD hosts.
   # connection: local
 
   # Should be fine to gather facts for just the future LXD host
@@ -25,19 +28,14 @@
 
 
 - name: Setup LXD test environment
-  hosts: all
+  hosts: localhost
 
   # Rely on this setting to be specified in host_vars or group_vars files. If
   # we lock in the 'local' option here then that rules out connecting via SSH
   # later, perhaps as a means of validating earlier playbook tasks.
   # connection: local
 
-  # This is needed due to potential for multiple access attempts via modules
-  # that are not intended/designed for it. Without this setting occasional
-  # race conditions occur which results in data corruption.
-  serial: 1
-
-  # Rely on specific tasks to call setup module as needed
+  # This is handled by the earlier atc0005.lxd-host role play
   gather_facts: no
 
   tasks:
@@ -48,6 +46,22 @@
       import_role:
         name: atc0005.lxd-testenv
       vars:
+
+##############################################################################
+        # NOTE: The most common supported role varibles with values set to
+        # their default state are included below. There are more; see the
+        # README file for the atc0005.lxd-testenv role for more information.
+        # https://github.com/atc0005/ansible-role-lxd-testenv
+        #
+        # Instead of setting values here for ALL hosts, you can also set
+        # values per group or per host in the test inventory files. For
+        # example, if you wish to have additional CentOS specific packages
+        # installed in the CentOS test containers, update the
+        # inventories/testing/group_vars/centos.yml file to include the list
+        # of packages. See the 'lxd_containers_packages_extra' variable set
+        # within this file for an example.
+##############################################################################
+
         # Valid values: "create" and "remove"
         state: "create"
 
@@ -57,5 +71,84 @@
         #
         # Note: The 'overlay' Docker storage driver is compatible with LXD's
         # "dir" storage and  is supposed to give better performance, so use
-        # that option if it is available to you.
+        # that option if it is available to you. If using LXD 3.0.x, the same
+        # "dir" LXD storage, and docker-ce 18.09.1~3-0~ubuntu-xenial you will
+        # need to use the custom 'docker' LXD container profile created by
+        # this role OR run the following command (replace the container name
+        # as needed):
+        #
+        # lxc config set ansible-ubuntu-docker linux.kernel_modules "overlay"
+        #
+        # Example:
         # lxd_containers_docker_storage_driver: "overlay"
+
+        # Update the $HOME/.ssh/config file for the user currently running Ansible
+        # playbook.
+        lxd_host_update_ssh_client_user_config_file: false
+
+        # Update the /etc/ssh/config file on the host.
+        lxd_host_update_ssh_client_system_config_file: true
+
+        # Update the $HOME/.ssh/known_hosts file on the host with host keys from all
+        # containers.
+        lxd_host_update_user_known_hosts_file: false
+
+        # Update the /etc/ssh/known_hosts file on the host with host keys from all
+        # containers.
+        lxd_host_update_system_known_hosts_file: false
+
+        # Flag used to control whether the `/etc/hosts` file on the LXD container host
+        # is updated to include new container name/IP pairs
+        lxd_host_update_etc_hosts_file: true
+
+        # Keys specific/dedicated to this role
+        #lxd_host_ssh_private_key_for_containers: "{{ lookup('env','HOME') + '/.ssh/id_ed25519' }}"
+        #lxd_host_ssh_public_key_for_containers: "{{ lxd_host_ssh_private_key_for_containers + '.pub' }}"
+
+        # Should the /etc/hosts file on each container be updated to list all other
+        # containers? If this is not enabled, then built-in dnsmasq support will be
+        # used to provide name resolution between containers.
+        lxd_containers_update_hosts_file: false
+
+        # Proxy server that can be used to speed up package installation within
+        # containers IMPORTANT: Make sure to provide the full URI scheme. If not set
+        # (or set empty), empty environment variables will be defined and as a result
+        # no  proxy server will be used.
+        # https://askubuntu.com/questions/228530/updating-http-proxy-environment-variable
+        # https://lxd.readthedocs.io/en/latest/environment/
+        # lxd_containers_proxy_server: "http://proxy.example.com:3128/"
+        lxd_containers_proxy_server: ""
+
+        # Should the /etc/environment file be updated to set proxy server settings?
+        # Note: This is safe to enable, even if the default value in this variables
+        # file is an empty string as the user may opt to set it at the playbook level.
+        lxd_containers_add_proxy_to_etc_environment_file: true
+
+        # Assume that containers should be created when this role is used
+        # unless overridden
+        lxd_containers_create: true
+
+        # Flag that controls whether Python, sudo and other packages are installed as
+        # part of preparing new containers for management by Ansible.
+        lxd_containers_bootstrap: true
+
+        # Create service account, groups, enable SSH at boot, etc
+        lxd_containers_configure: true
+
+        # Non-essential packages installed in each container
+        lxd_containers_packages_extra:
+          - "nano"
+
+        # All profiles listed here will be applied to newly created containers
+        lxd_containers_profiles:
+          - "default"
+
+        # Configuration settings for "service" account used within containers.
+        # Intended to match recommendations from training material which
+        # encourages the use of a dedicated "Ansible" account for remote
+        # management work.
+        lxd_containers_sudoers_include_file: "/etc/sudoers.d/ansible"
+        lxd_containers_service_account: "ansible"
+        lxd_containers_service_group: "ansible"
+
+...

--- a/requirements.yml
+++ b/requirements.yml
@@ -6,11 +6,11 @@
 
 - name: "atc0005.lxd-host"
   src: "https://github.com/atc0005/ansible-role-lxd-host.git"
-  version: "initial-import-from-incubator-repo"
+  version: "v0.1-alpha"
 
 - name: "atc0005.lxd-testenv"
   src: "https://github.com/atc0005/ansible-role-lxd-testenv.git"
-  version: "v1.0"
+  version: "v1.1"
 
 ...
 

--- a/scratch_work/lxd-setup-using-env-vars.yml
+++ b/scratch_work/lxd-setup-using-env-vars.yml
@@ -1,0 +1,50 @@
+---
+
+- name: Testing
+  hosts: localhost
+  # https://blog.codecentric.de/en/2017/06/debug-ansible-playbooks-like-pro/
+  strategy: debug
+  connection: local
+  gather_facts: yes
+
+  vars:
+    lxd_containers_image_server: "https://images.linuxcontainers.org"
+    lxd_image_source: "ubuntu/xenial/amd64"
+    lxd_containers_profiles:
+      - "default"
+      - "docker"
+    #proxy_server_for_containers: "http://proxy.example.com:3128/"
+
+  tasks:
+
+    - name: Create container with specific environment variables set
+      block:
+        - name: Create test container
+          delegate_to: localhost
+          lxd_container:
+            name: "ubuntu-testing"
+            state: started
+            config:
+              "environment.http_proxy": "{{ proxy_server_for_containers | default('') }}"
+              "environment.https_proxy": "{{ proxy_server_for_containers | default('') }}"
+              "environment.ftp_proxy": "{{ proxy_server_for_containers | default('') }}"
+            source:
+              type: image
+              mode: pull
+              server: "{{ lxd_containers_image_server }}"
+              protocol: lxd
+              alias: "{{ lxd_image_source }}"
+            profiles: "{{ lxd_containers_profiles }}"
+            wait_for_ipv4_addresses: true
+            timeout: 600
+          register: container_creation_results
+      always:
+        - name: Display container creation results
+          debug:
+            var: container_creation_results
+            #verbosity: 1
+      tags:
+        - create
+
+
+...

--- a/scratch_work/test.yml
+++ b/scratch_work/test.yml
@@ -1,0 +1,89 @@
+---
+
+- name: Testing
+  hosts: localhost
+  # https://blog.codecentric.de/en/2017/06/debug-ansible-playbooks-like-pro/
+  strategy: debug
+  connection: local
+  gather_facts: yes
+
+  vars:
+    lxc_containers_python_path: "/usr/bin/python"
+
+  tasks:
+
+    - name: Confirm python is installed in container
+      delegate_to: "{{ item }}"
+      delegate_facts: false
+      raw: "test -e {{ lxc_containers_python_path }}"
+      register: python_install_check
+      failed_when: python_install_check['rc'] not in [0, 1]
+      changed_when: false
+      with_items:
+        - "{{ groups['all'] }}"
+
+    # item.0 is the key of the item
+    # item.1 is the value of the item
+    # - name: DEBUG | Display variable
+    #   debug:
+    #     msg: "key is {{ item.0 }}, value is {{ item.1 }}"
+    #   with_indexed_items:
+    #     - "{{ python_install_check['results'] }}"
+
+    # - name: DEBUG | Python install check results with index
+    #   debug:
+    #     msg: >-
+    #       {{ item.1.item }} |
+    #       {{ 'Python is installed' if ( item.1.rc == 0)
+    #           else 'Python is NOT installed'
+    #       }}
+    #   #when: item.1.rc == 1
+    #   with_indexed_items:
+    #     - "{{ python_install_check['results'] }}"
+
+
+    # - name: DEBUG | Python install check results with items
+    #   debug:
+    #     msg: >-
+    #       {{ item.item }} |
+    #       {{ 'Python is installed' if ( item.rc == 0)
+    #           else 'Python is NOT installed'
+    #       }}
+    #   #when: item.1.rc == 1
+    #   with_items:
+    #     - "{{ python_install_check['results'] }}"
+
+
+    # - name: DEBUG | Python install check results using with_items
+    #   debug:
+    #     var: item
+    #   with_items:
+    #     - "{{ python_install_check['results'] }}"
+    #   loop_control:
+    #     label: "{{ item.item }}"
+
+    - name: DEBUG | Python install check results using loop
+      debug:
+        var: item
+      loop:
+        "{{ python_install_check['results'] | flatten(levels=1) }}"
+      loop_control:
+        label: "{{ item.item }}"
+
+      #loop:
+      #  - "{{ python_install_check['results'] | flatten(levels=1)}}"
+      #loop_control:
+      #  label: "{{ item.item }}"
+
+    - name: DEBUG | Python install check results
+      debug:
+        var: python_install_check['results']
+        verbosity: 1
+
+    - name: DEBUG | Variables for host
+      debug:
+        var: hostvars[item]
+        verbosity: 1
+      with_items:
+        - "{{ groups['all'] }}"
+...

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Purpose: VERY crude test control script to ease repetitive test steps
+
+show_conf_file_contents() {
+
+    declare -a conf_files
+
+    conf_files=(
+        "$HOME/.ssh/config"
+        "$HOME/.ssh/known_hosts"
+        "/etc/ssh/ssh_config"
+        "/etc/ssh/known_hosts"
+    )
+
+    for file in "${conf_files[@]}"
+    do
+        clear
+        echo "$file"
+        if [[ -f "$file" ]]
+        then
+            tail $file
+        else
+            echo "$file not found"
+        fi
+        sleep 4
+        echo
+    done
+
+}
+
+echo "Installing roles ..."
+ansible-galaxy install -r requirements.yml -p roles --force
+
+show_conf_file_contents
+
+echo "Running site.yml to spin up test environment ..."
+ansible-playbook -i inventories/testing site.yml -K
+
+show_conf_file_contents
+
+echo "Running lxd-remove.yml to tear down test environment ..."
+ansible-playbook -i inventories/testing lxd-remove.yml -K
+


### PR DESCRIPTION
- Playbooks target localhost exclusively instead of 'all' inventory hosts

- New LXD "benchmark" doc to reflect timing for playbooks using new default options against LXD 'dir' and 'zfs' storage options (the two most common)

- Expanded network configuration details, though admittedly most of the heavy lifting has been offloaded to the external guides linked from the References section

- Added warning reminding reader to log out and back in after running lxd init (I keep forgetting myself)

- Add coverage of Docker storage drivers recommending 'vfs' for the best stability, 'overlay' for the better performance if supported by backing LXD filesystem

- Use known atc0005.lxd-host role tag for stability

- Prune duplicate fact gathering

- Update ref links, timing details, version refs

- Various test/scratch scripts stashed for later use