### PR TITLE
Comment out empty proxy server var

### DIFF
--- a/lxd-setup.yml
+++ b/lxd-setup.yml
@@ -117,7 +117,7 @@
         # https://askubuntu.com/questions/228530/updating-http-proxy-environment-variable
         # https://lxd.readthedocs.io/en/latest/environment/
         # lxd_containers_proxy_server: "http://proxy.example.com:3128/"
-        lxd_containers_proxy_server: ""
+        # lxd_containers_proxy_server: ""
 
         # Should the /etc/environment file be updated to set proxy server settings?
         # Note: This is safe to enable, even if the default value in this variables


### PR DESCRIPTION
By leaving it within playbook as a defined empty string we were unintentionally ignoring any future definition of the variable within host_vars, group_vars or another valid location that has precedence over the role default.