### PR TITLE
Remove verbose comments, comment out default vars

### DIFF
--- a/lxd-setup.yml
+++ b/lxd-setup.yml
@@ -47,7 +47,7 @@
         name: atc0005.lxd-testenv
       vars:
 
-##############################################################################
+        #######################################################################
         # NOTE: The most common supported role varibles with values set to
         # their default state are included below. There are more; see the
         # README file for the atc0005.lxd-testenv role for more information.
@@ -60,95 +60,35 @@
         # inventories/testing/group_vars/centos.yml file to include the list
         # of packages. See the 'lxd_containers_packages_extra' variable set
         # within this file for an example.
-##############################################################################
+        #######################################################################
 
         # Valid values: "create" and "remove"
         state: "create"
 
-        # This role's default Docker storage setting is 'vfs', which works and
-        # is likely the most compatible option available, but is very slow.
-        # Override when possible to use a newer storage driver.
-        #
-        # Note: The 'overlay' Docker storage driver is compatible with LXD's
-        # "dir" storage and  is supposed to give better performance, so use
-        # that option if it is available to you. If using LXD 3.0.x, the same
-        # "dir" LXD storage, and docker-ce 18.09.1~3-0~ubuntu-xenial you will
-        # need to use the custom 'docker' LXD container profile created by
-        # this role OR run the following command (replace the container name
-        # as needed):
-        #
-        # lxc config set ansible-ubuntu-docker linux.kernel_modules "overlay"
-        #
-        # Example:
+        # lxd_containers_docker_storage_driver: "vfs"
         # lxd_containers_docker_storage_driver: "overlay"
-
-        # Update the $HOME/.ssh/config file for the user currently running Ansible
-        # playbook.
-        lxd_host_update_ssh_client_user_config_file: false
-
-        # Update the /etc/ssh/config file on the host.
-        lxd_host_update_ssh_client_system_config_file: true
-
-        # Update the $HOME/.ssh/known_hosts file on the host with host keys from all
-        # containers.
-        lxd_host_update_user_known_hosts_file: false
-
-        # Update the /etc/ssh/known_hosts file on the host with host keys from all
-        # containers.
-        lxd_host_update_system_known_hosts_file: false
-
-        # Flag used to control whether the `/etc/hosts` file on the LXD container host
-        # is updated to include new container name/IP pairs
-        lxd_host_update_etc_hosts_file: true
-
-        # Keys specific/dedicated to this role
-        #lxd_host_ssh_private_key_for_containers: "{{ lookup('env','HOME') + '/.ssh/id_ed25519' }}"
-        #lxd_host_ssh_public_key_for_containers: "{{ lxd_host_ssh_private_key_for_containers + '.pub' }}"
-
-        # Should the /etc/hosts file on each container be updated to list all other
-        # containers? If this is not enabled, then built-in dnsmasq support will be
-        # used to provide name resolution between containers.
-        lxd_containers_update_hosts_file: false
-
-        # Proxy server that can be used to speed up package installation within
-        # containers IMPORTANT: Make sure to provide the full URI scheme. If not set
-        # (or set empty), empty environment variables will be defined and as a result
-        # no  proxy server will be used.
-        # https://askubuntu.com/questions/228530/updating-http-proxy-environment-variable
-        # https://lxd.readthedocs.io/en/latest/environment/
+        # lxd_host_update_ssh_client_user_config_file: false
+        # lxd_host_update_ssh_client_system_config_file: true
+        # lxd_host_update_user_known_hosts_file: false
+        # lxd_host_update_system_known_hosts_file: false
+        # lxd_host_update_etc_hosts_file: true
+        # lxd_host_ssh_private_key_for_containers: "{{ lookup('env','HOME') + '/.ssh/id_ed25519' }}"
+        # lxd_host_ssh_public_key_for_containers: "{{ lxd_host_ssh_private_key_for_containers + '.pub' }}"
+        # lxd_containers_update_hosts_file: false
         # lxd_containers_proxy_server: "http://proxy.example.com:3128/"
-        # lxd_containers_proxy_server: ""
-
-        # Should the /etc/environment file be updated to set proxy server settings?
-        # Note: This is safe to enable, even if the default value in this variables
-        # file is an empty string as the user may opt to set it at the playbook level.
-        lxd_containers_add_proxy_to_etc_environment_file: true
-
-        # Assume that containers should be created when this role is used
-        # unless overridden
-        lxd_containers_create: true
-
-        # Flag that controls whether Python, sudo and other packages are installed as
-        # part of preparing new containers for management by Ansible.
-        lxd_containers_bootstrap: true
-
-        # Create service account, groups, enable SSH at boot, etc
-        lxd_containers_configure: true
-
-        # Non-essential packages installed in each container
-        lxd_containers_packages_extra:
-          - "nano"
-
-        # All profiles listed here will be applied to newly created containers
-        lxd_containers_profiles:
-          - "default"
-
-        # Configuration settings for "service" account used within containers.
-        # Intended to match recommendations from training material which
-        # encourages the use of a dedicated "Ansible" account for remote
-        # management work.
-        lxd_containers_sudoers_include_file: "/etc/sudoers.d/ansible"
-        lxd_containers_service_account: "ansible"
-        lxd_containers_service_group: "ansible"
+        # lxd_containers_add_proxy_to_etc_environment_file: true
+        # lxd_containers_create: true
+        # lxd_containers_bootstrap: true
+        # lxd_containers_configure: true
+        #
+        # lxd_containers_packages_extra:
+        #   - "nano"
+        #
+        # lxd_containers_profiles:
+        #   - "default"
+        #
+        # lxd_containers_sudoers_include_file: "/etc/sudoers.d/ansible"
+        # lxd_containers_service_account: "ansible"
+        # lxd_containers_service_group: "ansible"
 
 ...


### PR DESCRIPTION
Instead of leaving built-in doc comments, direct user to the main README in an effort to condense the amount of information that needs to be reviewed when altering settings.

Also, comment out default variables to help prevent overriding group_vars or host_vars entries.

fixes #6