### PR TITLE
Expose LXD image server and src, sort vars

### DIFF
--- a/lxd-setup.yml
+++ b/lxd-setup.yml
@@ -65,21 +65,26 @@
         # Valid values: "create" and "remove"
         state: "create"
 
-        # lxd_containers_docker_storage_driver: "vfs"
-        # lxd_containers_docker_storage_driver: "overlay"
-        # lxd_host_update_ssh_client_user_config_file: false
-        # lxd_host_update_ssh_client_system_config_file: true
         # lxd_host_update_user_known_hosts_file: false
         # lxd_host_update_system_known_hosts_file: false
+        # lxd_host_update_ssh_client_user_config_file: false
+        # lxd_host_update_ssh_client_system_config_file: true
         # lxd_host_update_etc_hosts_file: true
-        # lxd_host_ssh_private_key_for_containers: "{{ lookup('env','HOME') + '/.ssh/id_ed25519' }}"
         # lxd_host_ssh_public_key_for_containers: "{{ lxd_host_ssh_private_key_for_containers + '.pub' }}"
+        # lxd_host_ssh_private_key_for_containers: "{{ lookup('env','HOME') + '/.ssh/id_ed25519' }}"
         # lxd_containers_update_hosts_file: false
+        # lxd_containers_sudoers_include_file: "/etc/sudoers.d/ansible"
+        # lxd_containers_service_group: "ansible"
+        # lxd_containers_service_account: "ansible"
         # lxd_containers_proxy_server: "http://proxy.example.com:3128/"
-        # lxd_containers_add_proxy_to_etc_environment_file: true
+        # lxd_containers_image_source: "ubuntu/xenial/amd64"
+        # lxd_containers_image_server: "https://images.linuxcontainers.org"
+        # lxd_containers_docker_storage_driver: "vfs"
+        # lxd_containers_docker_storage_driver: "overlay"
         # lxd_containers_create: true
-        # lxd_containers_bootstrap: true
         # lxd_containers_configure: true
+        # lxd_containers_bootstrap: true
+        # lxd_containers_add_proxy_to_etc_environment_file: true
         #
         # lxd_containers_packages_extra:
         #   - "nano"
@@ -87,8 +92,5 @@
         # lxd_containers_profiles:
         #   - "default"
         #
-        # lxd_containers_sudoers_include_file: "/etc/sudoers.d/ansible"
-        # lxd_containers_service_account: "ansible"
-        # lxd_containers_service_group: "ansible"
 
 ...


### PR DESCRIPTION
Expose image server URL and source image used to spin up containers if not specified elsewhere.