### PR TITLE
Update playbooks, docs to match v1.1.3 role

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,15 @@ configured which are intended to allow easy override of the base settings
 defined within the `defaults/main.yml` file included within the
 `atc0005.lxd-testenv` role.
 
+While you *can* override those settings within the playbook, doing so at that
+level applies the setting across *all* containers. You will likely get better
+results by applying overrides at `group_vars` or even `host_vars` level.
+
+For example, if you wish to use Ubuntu 18.04 (bionic) instead of the default
+Ubuntu 16.04 (xenial), you should modify the `group_vars/ubuntu.yml` file to
+specify the desired image instead of setting this as the playbook level where
+it would override the CentOS 7 image specificed for CentOS containers.
+
 See these docs for more information:
 
 - [lxd-setup](docs/lxd-setup.md)

--- a/lxd-remove.yml
+++ b/lxd-remove.yml
@@ -12,7 +12,7 @@
 # Prune container settings after completion of test work
 
 - name: Tear down our LXD test environment
-  hosts: localhost
+  hosts: all
 
   # Rely on this setting to be specified in host_vars or group_vars files. If
   # we lock in the 'local' option here then that rules out connecting via SSH

--- a/lxd-setup-containers.yml
+++ b/lxd-setup-containers.yml
@@ -7,35 +7,15 @@
 # https://github.com/atc0005/ansible-playbook-lxd-testenv
 # https://github.com/atc0005/ansible-role-lxd-testenv
 
-- name: Configure base LXD host
-  hosts: localhost
-
-  # Rely on this setting to be specified in host_vars or group_vars files. If
-  # we lock in the 'local' option here then that rules out setting up any
-  # remote hosts as LXD hosts.
-  # connection: local
-
-  # Should be fine to gather facts for just the future LXD host
-  gather_facts: yes
-
-  tasks:
-
-    # Stub role for now. Later work will have it install required packages
-    # needed in order to configure host system for running LXD containers
-    - name: Apply lxd-host role to install LXD packages, perform initial setup
-      import_role:
-        name: atc0005.lxd-host
-
-
 - name: Setup LXD test environment
-  hosts: localhost
+  hosts: all
 
   # Rely on this setting to be specified in host_vars or group_vars files. If
   # we lock in the 'local' option here then that rules out connecting via SSH
   # later, perhaps as a means of validating earlier playbook tasks.
   # connection: local
 
-  # This is handled by the earlier atc0005.lxd-host role play
+  # Fact gathering is explicitly forced later as needed.
   gather_facts: no
 
   tasks:
@@ -53,13 +33,20 @@
         # README file for the atc0005.lxd-testenv role for more information.
         # https://github.com/atc0005/ansible-role-lxd-testenv
         #
-        # Instead of setting values here for ALL hosts, you can also set
-        # values per group or per host in the test inventory files. For
-        # example, if you wish to have additional CentOS specific packages
+        # INSTEAD OF SETTING VALUES HERE FOR ALL HOSTS, YOU CAN ALSO SET
+        # VALUES PER GROUP OR PER HOST IN THE TEST INVENTORY FILES.
+        #
+        # For example, if you wish to have additional CentOS specific packages
         # installed in the CentOS test containers, update the
         # inventories/testing/group_vars/centos.yml file to include the list
         # of packages. See the 'lxd_containers_packages_extra' variable set
         # within this file for an example.
+        #
+        # Likewise, if you wish to use Ubuntu 18.04 in place of Ubuntu 16.04
+        # (which is used by default in Ubuntu containers), modify the
+        # inventories/testing/group_vars/ubuntu.yml file to specify bionic
+        # instead of xenial.
+        #
         #######################################################################
 
         # Valid values: "create" and "remove"

--- a/lxd-setup-host.yml
+++ b/lxd-setup-host.yml
@@ -1,0 +1,29 @@
+---
+
+# vim: ts=2:sw=2:et:ft=yaml
+# -*- mode: yaml; indent-tabs-mode: nil; tab-width: 2 -*-
+# code: language=yaml insertSpaces=true tabSize=2
+
+# https://github.com/atc0005/ansible-playbook-lxd-testenv
+# https://github.com/atc0005/ansible-role-lxd-testenv
+
+- name: Configure base LXD host
+  hosts: localhost
+
+  # Rely on this setting to be specified in host_vars or group_vars files. If
+  # we lock in the 'local' option here then that rules out setting up any
+  # remote hosts as LXD hosts.
+  # connection: local
+
+  # Should be fine to gather facts for just the future LXD host
+  gather_facts: yes
+
+  tasks:
+
+    # Stub role for now. Later work will have it install required packages
+    # needed in order to configure host system for running LXD containers
+    - name: Apply lxd-host role to install LXD packages, perform initial setup
+      import_role:
+        name: atc0005.lxd-host
+
+...

--- a/requirements.yml
+++ b/requirements.yml
@@ -10,7 +10,7 @@
 
 - name: "atc0005.lxd-testenv"
   src: "https://github.com/atc0005/ansible-role-lxd-testenv.git"
-  version: "v1.1.2"
+  version: "v1.1.3"
 
 ...
 

--- a/site.yml
+++ b/site.yml
@@ -1,6 +1,7 @@
 ---
 
-- import_playbook: lxd-setup.yml
+- import_playbook: lxd-setup-host.yml
+- import_playbook: lxd-setup-containers.yml
 - import_playbook: docker-setup.yml
 
 ...


### PR DESCRIPTION
- Split setup playbook into playbook for LXD host
  and another for setting up containers.
  - host setup playbook targets localhost as
    originally intended
  - container setup playbook targets 'all' inventory
    in an effort to work around logic and precedence
    issues caused by earlier approach of running all
    tasks against localhost with explicit looping and
    delegation to containers.

- Update README to cover role changes

refs atc0005/ansible-role-lxd-testenv#32