### PR TITLE
Add ansible.cfg options to enable profiling

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,12 @@
+# vim: ts=4:sw=4:et:ft=ini
+# -*- mode: ini; indent-tabs-mode: nil; tab-width: 4 -*-
+# code: language=ini insertSpaces=true tabSize=4
+
+# https://github.com/atc0005/ansible-playbook-lxd-testenv
+# https://github.com/atc0005/ansible-role-lxd-testenv
+
+[defaults]
+
+# Enable per-play, per-role and final summary of timing statistics
+# https://docs.ansible.com/ansible/latest/plugins/callback.html
+callback_whitelist = profile_tasks, profile_roles, timer


### PR DESCRIPTION
## Overview

This info is provided by using native Ansible callback plugins:

- profile_tasks
- profile_roles
- timer

## Changes

This PR enables use of these plugins by modifying `ansible.cfg` to whitelist the specific callback plugins. No action is required by playbook user in order to enable stats display.

## References

- https://docs.ansible.com/ansible/latest/plugins/callback.html
  - https://docs.ansible.com/ansible/latest/plugins/callback/profile_roles.html
  - https://docs.ansible.com/ansible/latest/plugins/callback/profile_tasks.html
  - https://docs.ansible.com/ansible/latest/plugins/callback/timer.html
- https://www.reddit.com/r/ansible/comments/94caff/how_to_time_playbook/
- http://techadminblog.com/get-execution-time-of-each-task-ansible/

fixes #16