### PR TITLE
Update README to ref new files, add TOC to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,24 @@
-# lxd-testenv playbooks
+# Ansible Playbooks: lxd-testenv
 
 *Small suite of playbooks intended to help quickly spin up a test environment
 for other playbook work.*
 
 ## Overview
 
-| Name                       | Purpose (short)                                                      | Documentation                                                                |
-| -------------------------- | -------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| `site.yml`                 | Call `lxd-setup.yml` and `docker-setup.yml`                          | [lxd-setup.yml](docs/lxd-setup.md), [docker-setup.yml](docs/docker-setup.md) |
-| `docker-setup.yml`         | Install packages, configure specified hosts to run Docker containers | [playbook](docs/docker-setup.md)                                             |
-| `lxd-setup-host.yml`       | Setup LXD container host to run test containers                      | [playbook](docs/lxd-setup.md)                                                |
-| `lxd-setup-containers.yml` | Create LXD containers for testing purposes                           | [playbook](docs/lxd-setup.md)                                                |
-| `lxd-remove.yml`           | Tear down LXD container test environment                             | [playbook](docs/lxd-remove.md)                                               |
+| Name                       | Purpose (short)                                                      | Documentation                            |
+| -------------------------- | -------------------------------------------------------------------- | ---------------------------------------- |
+| `site.yml`                 | Call all "setup" playbooks needed to spin up test environment.       | See individual entries below             |
+| `lxd-setup-host.yml`       | Setup LXD container host to run test containers                      | [playbook](docs/lxd-setup-host.md)       |
+| `lxd-setup-containers.yml` | Create LXD containers for testing purposes                           | [playbook](docs/lxd-setup-containers.md) |
+| `docker-setup.yml`         | Install packages, configure specified hosts to run Docker containers | [playbook](docs/docker-setup.md)         |
+| `lxd-remove.yml`           | Tear down LXD container test environment                             | [playbook](docs/lxd-remove.md)           |
 
-See [lxd-timing](docs/lxd-timing.md) for *very* rough estimates on the time
+- See [lxd-timing](docs/lxd-timing.md) for *very* rough estimates on the time
 needed to spinup/teardown a test environment.
+
+- See [docker-storage-drivers](docs/docker-storage-drivers.md) for a quick
+  overview of known compatibility issues between LXD storage and Docker
+  storage drivers
 
 ## Limitations
 

--- a/docs/docker-setup.md
+++ b/docs/docker-setup.md
@@ -1,5 +1,15 @@
 # Ansible Playbook: docker-setup.yml
 
+## Table of Contents
+
+- [Ansible Playbook: docker-setup.yml](#ansible-playbook-docker-setupyml)
+  - [Table of Contents](#table-of-contents)
+  - [Overview](#overview)
+  - [Limitations](#limitations)
+  - [Requirements](#requirements)
+  - [Usage](#usage)
+  - [References](#references)
+
 ## Overview
 
 Small playbook that uses the `atc0005.docker-host` role to install Docker
@@ -15,8 +25,7 @@ installing Docker within LXD containers for isolated testing.
 ## Requirements
 
 1. Move into directory containing inventories and playbooks dir
-1. Install required roles
-    - `ansible-galaxy install -r requirements.yml -p roles --force`
+1. [Install required roles](install-roles.md)
 
 ## Usage
 
@@ -24,6 +33,11 @@ Run playbook against relevant inventory. In this case, we target our
 testing inventory from the main directory:
 
 `ansible-playbook -i inventories/testing docker-setup.yml -K`
+
+This step is handled automatically as part of using the site-wide playbook,
+`site.yml`:
+
+`ansible-playbook -i inventories/testing site.yml -K`
 
 ## References
 

--- a/docs/docker-storage-drivers.md
+++ b/docs/docker-storage-drivers.md
@@ -1,5 +1,15 @@
 # Ansible Role: Docker storage (docker-setup.yml)
 
+## Table of Contents
+
+- [Ansible Role: Docker storage (docker-setup.yml)](#ansible-role-docker-storage-docker-setupyml)
+  - [Table of Contents](#table-of-contents)
+  - [LXD + Docker CE `overlay2` storage driver](#lxd--docker-ce-overlay2-storage-driver)
+  - [LXD + ZFS storage + Docker CE `overlay` or `overlay` storage driver](#lxd--zfs-storage--docker-ce-overlay-or-overlay-storage-driver)
+  - [LXD + `dir` storage + Docker `overlay` storage driver](#lxd--dir-storage--docker-overlay-storage-driver)
+  - [Docker `vfs` storage driver](#docker-vfs-storage-driver)
+  - [References](#references)
+
 ## LXD + Docker CE `overlay2` storage driver
 
 LXD 2.x or 3.x (regardless of LXD storage option) is incompatible with Docker

--- a/docs/install-roles.md
+++ b/docs/install-roles.md
@@ -1,5 +1,15 @@
 # Ansible Playbook: lxd-testenv
 
+## Table of contents
+
+- [Ansible Playbook: lxd-testenv](#ansible-playbook-lxd-testenv)
+  - [Table of contents](#table-of-contents)
+  - [Install roles needed for playbook use](#install-roles-needed-for-playbook-use)
+    - [Option 1: Within your home directory](#option-1-within-your-home-directory)
+    - [Option 2: Within a `roles` directory in the same location as playbooks](#option-2-within-a-roles-directory-in-the-same-location-as-playbooks)
+    - [Option 3: System-wide for all users](#option-3-system-wide-for-all-users)
+  - [See also](#see-also)
+
 ## Install roles needed for playbook use
 
 - While it is technically possible to install each role manually, a

--- a/docs/lxd-remove.md
+++ b/docs/lxd-remove.md
@@ -1,5 +1,16 @@
 # Ansible Playbook: lxd-remove.yml
 
+## Table of Contents
+
+- [Ansible Playbook: lxd-remove.yml](#ansible-playbook-lxd-removeyml)
+  - [Table of Contents](#table-of-contents)
+  - [Overview](#overview)
+  - [Limitations](#limitations)
+  - [Requirements](#requirements)
+  - [Usage](#usage)
+  - [Playbook runtime](#playbook-runtime)
+  - [References](#references)
+
 ## Overview
 
 Small playbook that uses the `atc0005.lxd-testenv` role to tear down or remove
@@ -15,8 +26,7 @@ a LXD-based testing environment previously created by running the
 ## Requirements
 
 1. Move into directory containing inventories and playbooks dir
-1. Install required roles
-    - `ansible-galaxy install -r requirements.yml -p roles --force`
+1. [Install required roles](install-roles.md)
 
 ## Usage
 

--- a/docs/lxd-setup-containers.md
+++ b/docs/lxd-setup-containers.md
@@ -1,4 +1,17 @@
-# Ansible Playbook: lxd-setup.yml
+# Ansible Playbook: lxd-setup-containers.yml
+
+## Table of Contents
+
+- [Ansible Playbook: lxd-setup-containers.yml](#ansible-playbook-lxd-setup-containersyml)
+  - [Table of Contents](#table-of-contents)
+  - [Overview](#overview)
+  - [Limitations](#limitations)
+  - [Requirements](#requirements)
+    - [Install roles](#install-roles)
+    - [Install LXD packages, perform initial configuration](#install-lxd-packages-perform-initial-configuration)
+  - [Usage](#usage)
+  - [Playbook runtime](#playbook-runtime)
+  - [References](#references)
 
 ## Overview
 
@@ -22,8 +35,7 @@ environment.
 ### Install roles
 
 1. Move into directory containing inventories, and playbooks dir
-1. Install required roles
-    - `ansible-galaxy install -r requirements.yml -p roles --force`
+1. [Install required roles](install-roles.md)
 
 ### Install LXD packages, perform initial configuration
 
@@ -36,7 +48,12 @@ containers for local testing purposes.
 Run playbook against relevant inventory. In this case, we target our
 testing inventory from the main directory:
 
-`ansible-playbook -i inventories/testing lxd-setup.yml -K`
+`ansible-playbook -i inventories/testing lxd-setup-containers.yml -K`
+
+This step is handled automatically as part of using the site-wide playbook,
+`site.yml`:
+
+`ansible-playbook -i inventories/testing site.yml -K`
 
 ## Playbook runtime
 

--- a/docs/lxd-setup-host.md
+++ b/docs/lxd-setup-host.md
@@ -1,0 +1,72 @@
+# Ansible Playbook: lxd-setup-host.yml
+
+## WARNING
+
+This playbook does not actually *do* anything yet. The role referenced by this
+playbook is a stub only. When that role is finally fleshed out to actually
+setup a host this section will be removed.
+
+## Table of contents
+
+- [Ansible Playbook: lxd-setup-host.yml](#ansible-playbook-lxd-setup-hostyml)
+  - [WARNING](#warning)
+  - [Table of contents](#table-of-contents)
+  - [Overview](#overview)
+  - [Limitations](#limitations)
+  - [Requirements](#requirements)
+    - [Install roles](#install-roles)
+    - [Install LXD packages, perform initial configuration](#install-lxd-packages-perform-initial-configuration)
+  - [Usage](#usage)
+  - [Playbook runtime](#playbook-runtime)
+  - [References](#references)
+
+## Overview
+
+A small playbook that uses the `atc0005.lxd-host` role to configure an Ubuntu
+system to run LXD containers.
+
+The [`lxd-remove.yml`](lxd-remove.md) playbook is intended to tear down the
+test environment as needed in order to refresh the environment. While it does
+remove container-specific settings from the host, it does not remove any
+packages or system-wide changes made to the host which are not container
+specific (e.g., creation of NAT bridge, etc.)
+
+## Limitations
+
+- This playbook relies upon the `atc0005.lxd-host` role. As of this writing it
+  is only compatible with Ubuntu. Because of this, this playbook is only
+  compatible with Ubuntu.
+
+## Requirements
+
+### Install roles
+
+1. Move into directory containing inventories, and playbooks dir
+1. [Install required roles](install-roles.md)
+
+### Install LXD packages, perform initial configuration
+
+For now, see the `atc0005.lxd-testenv` role [README](#references) for the
+specific packages and steps needed to prepare an Ubuntu system to run LXD
+containers for local testing purposes.
+
+## Usage
+
+Run playbook against relevant inventory. In this case, we target our
+testing inventory from the main directory:
+
+`ansible-playbook -i inventories/testing lxd-setup-host.yml -K`
+
+This step is handled automatically as part of using the site-wide playbook,
+`site.yml`:
+
+`ansible-playbook -i inventories/testing site.yml -K`
+
+## Playbook runtime
+
+N/A (see WARNING above)
+
+## References
+
+- <https://github.com/atc0005/ansible-playbook-lxd-testenv>
+- <https://github.com/atc0005/ansible-playbook-lxd-testenv/blob/master/README.md>


### PR DESCRIPTION
- New doc files to reflect split playbooks 
  - minor tweaks made in v1.1.4 to cover this but they were too brief to cover change

- Add TOC to each doc file

- Update README listing of playbooks to ref new files, existing storage drivers doc

- Update separate doc files to reflect role install doc instead of reinventing the wheel

fixes #18 