### PR TITLE
Update timeout value to match role default

### DIFF
--- a/lxd-setup-containers.yml
+++ b/lxd-setup-containers.yml
@@ -82,7 +82,7 @@
         # lxd_containers_docker_storage_driver: "vfs"
         # lxd_containers_docker_storage_driver: "overlay"
         # lxd_containers_create: true
-        # lxd_containers_create_timeout: "20"
+        # lxd_containers_create_timeout: "600"
         # lxd_containers_wait_for_ipv4_addresses: true
         # lxd_containers_configure: true
         # lxd_containers_bootstrap: true


### PR DESCRIPTION
The previous value does not match the current v1.2.0 role default value. This PR corrects that.