### PR TITLE
Add modelines to host_vars, group_vars files

### DIFF
--- a/inventories/testing/group_vars/all.yml
+++ b/inventories/testing/group_vars/all.yml
@@ -1,5 +1,13 @@
 ---
 
+# vim: ts=2:sw=2:et:ft=yaml
+# -*- mode: yaml; indent-tabs-mode: nil; tab-width: 2 -*-
+# code: language=yaml insertSpaces=true tabSize=2
+
+# https://github.com/atc0005/ansible-playbook-lxd-testenv
+# https://github.com/atc0005/ansible-role-lxd-testenv
+
+
 # This file is for variables that apply to all hosts in this inventory.
 
 ...

--- a/inventories/testing/group_vars/centos.yml
+++ b/inventories/testing/group_vars/centos.yml
@@ -1,5 +1,13 @@
 ---
 
+# vim: ts=2:sw=2:et:ft=yaml
+# -*- mode: yaml; indent-tabs-mode: nil; tab-width: 2 -*-
+# code: language=yaml insertSpaces=true tabSize=2
+
+# https://github.com/atc0005/ansible-playbook-lxd-testenv
+# https://github.com/atc0005/ansible-role-lxd-testenv
+
+
 # Defines what container image is used
 # See https://images.linuxcontainers.org/ for supported options
 # Specify using 'distribution/release/architecture' format

--- a/inventories/testing/group_vars/lxd-all-containers.yml
+++ b/inventories/testing/group_vars/lxd-all-containers.yml
@@ -1,5 +1,13 @@
 ---
 
+# vim: ts=2:sw=2:et:ft=yaml
+# -*- mode: yaml; indent-tabs-mode: nil; tab-width: 2 -*-
+# code: language=yaml insertSpaces=true tabSize=2
+
+# https://github.com/atc0005/ansible-playbook-lxd-testenv
+# https://github.com/atc0005/ansible-role-lxd-testenv
+
+
 # These are LXD containers, so use lxd connection type when making initial
 # connections for setup purposes.
 ansible_connection: "lxd"

--- a/inventories/testing/group_vars/lxd-hosts.yml
+++ b/inventories/testing/group_vars/lxd-hosts.yml
@@ -1,5 +1,13 @@
 ---
 
+# vim: ts=2:sw=2:et:ft=yaml
+# -*- mode: yaml; indent-tabs-mode: nil; tab-width: 2 -*-
+# code: language=yaml insertSpaces=true tabSize=2
+
+# https://github.com/atc0005/ansible-playbook-lxd-testenv
+# https://github.com/atc0005/ansible-role-lxd-testenv
+
+
 # Allow the installation of LXD packages necessary to create and manage LXD
 # containers. Apply this setting only to host systems in the lxd_hosts group.
 # Note: As of v1.0 of the role and associated playbooks, this option does

--- a/inventories/testing/group_vars/ubuntu.yml
+++ b/inventories/testing/group_vars/ubuntu.yml
@@ -1,5 +1,13 @@
 ---
 
+# vim: ts=2:sw=2:et:ft=yaml
+# -*- mode: yaml; indent-tabs-mode: nil; tab-width: 2 -*-
+# code: language=yaml insertSpaces=true tabSize=2
+
+# https://github.com/atc0005/ansible-playbook-lxd-testenv
+# https://github.com/atc0005/ansible-role-lxd-testenv
+
+
 # Defines what container image is used
 # See https://images.linuxcontainers.org/ for supported options
 # Specify using 'distribution/release/architecture' format

--- a/inventories/testing/host_vars/ansible-centos-1.yml
+++ b/inventories/testing/host_vars/ansible-centos-1.yml
@@ -1,5 +1,12 @@
 ---
 
+# vim: ts=2:sw=2:et:ft=yaml
+# -*- mode: yaml; indent-tabs-mode: nil; tab-width: 2 -*-
+# code: language=yaml insertSpaces=true tabSize=2
+
+# https://github.com/atc0005/ansible-playbook-lxd-testenv
+# https://github.com/atc0005/ansible-role-lxd-testenv
+
 
 # This file is for variables specific to the host of the same name as this
 # file (minus extension of course)

--- a/inventories/testing/host_vars/ansible-centos-2.yml
+++ b/inventories/testing/host_vars/ansible-centos-2.yml
@@ -1,5 +1,12 @@
 ---
 
+# vim: ts=2:sw=2:et:ft=yaml
+# -*- mode: yaml; indent-tabs-mode: nil; tab-width: 2 -*-
+# code: language=yaml insertSpaces=true tabSize=2
+
+# https://github.com/atc0005/ansible-playbook-lxd-testenv
+# https://github.com/atc0005/ansible-role-lxd-testenv
+
 
 # This file is for variables specific to the host of the same name as this
 # file (minus extension of course)

--- a/inventories/testing/host_vars/ansible-centos-3.yml
+++ b/inventories/testing/host_vars/ansible-centos-3.yml
@@ -1,5 +1,12 @@
 ---
 
+# vim: ts=2:sw=2:et:ft=yaml
+# -*- mode: yaml; indent-tabs-mode: nil; tab-width: 2 -*-
+# code: language=yaml insertSpaces=true tabSize=2
+
+# https://github.com/atc0005/ansible-playbook-lxd-testenv
+# https://github.com/atc0005/ansible-role-lxd-testenv
+
 
 # This file is for variables specific to the host of the same name as this
 # file (minus extension of course)

--- a/inventories/testing/host_vars/ansible-centos-4.yml
+++ b/inventories/testing/host_vars/ansible-centos-4.yml
@@ -1,5 +1,12 @@
 ---
 
+# vim: ts=2:sw=2:et:ft=yaml
+# -*- mode: yaml; indent-tabs-mode: nil; tab-width: 2 -*-
+# code: language=yaml insertSpaces=true tabSize=2
+
+# https://github.com/atc0005/ansible-playbook-lxd-testenv
+# https://github.com/atc0005/ansible-role-lxd-testenv
+
 
 # This file is for variables specific to the host of the same name as this
 # file (minus extension of course)

--- a/inventories/testing/host_vars/ansible-centos-5.yml
+++ b/inventories/testing/host_vars/ansible-centos-5.yml
@@ -1,5 +1,12 @@
 ---
 
+# vim: ts=2:sw=2:et:ft=yaml
+# -*- mode: yaml; indent-tabs-mode: nil; tab-width: 2 -*-
+# code: language=yaml insertSpaces=true tabSize=2
+
+# https://github.com/atc0005/ansible-playbook-lxd-testenv
+# https://github.com/atc0005/ansible-role-lxd-testenv
+
 
 # This file is for variables specific to the host of the same name as this
 # file (minus extension of course)

--- a/inventories/testing/host_vars/ansible-ubuntu-1.yml
+++ b/inventories/testing/host_vars/ansible-ubuntu-1.yml
@@ -1,5 +1,12 @@
 ---
 
+# vim: ts=2:sw=2:et:ft=yaml
+# -*- mode: yaml; indent-tabs-mode: nil; tab-width: 2 -*-
+# code: language=yaml insertSpaces=true tabSize=2
+
+# https://github.com/atc0005/ansible-playbook-lxd-testenv
+# https://github.com/atc0005/ansible-role-lxd-testenv
+
 
 # This file is for variables specific to the host of the same name as this
 # file (minus extension of course)

--- a/inventories/testing/host_vars/ansible-ubuntu-2.yml
+++ b/inventories/testing/host_vars/ansible-ubuntu-2.yml
@@ -1,5 +1,12 @@
 ---
 
+# vim: ts=2:sw=2:et:ft=yaml
+# -*- mode: yaml; indent-tabs-mode: nil; tab-width: 2 -*-
+# code: language=yaml insertSpaces=true tabSize=2
+
+# https://github.com/atc0005/ansible-playbook-lxd-testenv
+# https://github.com/atc0005/ansible-role-lxd-testenv
+
 
 # This file is for variables specific to the host of the same name as this
 # file (minus extension of course)

--- a/inventories/testing/host_vars/ansible-ubuntu-3.yml
+++ b/inventories/testing/host_vars/ansible-ubuntu-3.yml
@@ -1,5 +1,12 @@
 ---
 
+# vim: ts=2:sw=2:et:ft=yaml
+# -*- mode: yaml; indent-tabs-mode: nil; tab-width: 2 -*-
+# code: language=yaml insertSpaces=true tabSize=2
+
+# https://github.com/atc0005/ansible-playbook-lxd-testenv
+# https://github.com/atc0005/ansible-role-lxd-testenv
+
 
 # This file is for variables specific to the host of the same name as this
 # file (minus extension of course)

--- a/inventories/testing/host_vars/ansible-ubuntu-4.yml
+++ b/inventories/testing/host_vars/ansible-ubuntu-4.yml
@@ -1,5 +1,12 @@
 ---
 
+# vim: ts=2:sw=2:et:ft=yaml
+# -*- mode: yaml; indent-tabs-mode: nil; tab-width: 2 -*-
+# code: language=yaml insertSpaces=true tabSize=2
+
+# https://github.com/atc0005/ansible-playbook-lxd-testenv
+# https://github.com/atc0005/ansible-role-lxd-testenv
+
 
 # This file is for variables specific to the host of the same name as this
 # file (minus extension of course)

--- a/inventories/testing/host_vars/ansible-ubuntu-5.yml
+++ b/inventories/testing/host_vars/ansible-ubuntu-5.yml
@@ -1,5 +1,12 @@
 ---
 
+# vim: ts=2:sw=2:et:ft=yaml
+# -*- mode: yaml; indent-tabs-mode: nil; tab-width: 2 -*-
+# code: language=yaml insertSpaces=true tabSize=2
+
+# https://github.com/atc0005/ansible-playbook-lxd-testenv
+# https://github.com/atc0005/ansible-role-lxd-testenv
+
 
 # This file is for variables specific to the host of the same name as this
 # file (minus extension of course)

--- a/inventories/testing/host_vars/ansible-ubuntu-docker.yml
+++ b/inventories/testing/host_vars/ansible-ubuntu-docker.yml
@@ -1,5 +1,12 @@
 ---
 
+# vim: ts=2:sw=2:et:ft=yaml
+# -*- mode: yaml; indent-tabs-mode: nil; tab-width: 2 -*-
+# code: language=yaml insertSpaces=true tabSize=2
+
+# https://github.com/atc0005/ansible-playbook-lxd-testenv
+# https://github.com/atc0005/ansible-role-lxd-testenv
+
 
 # This file is for variables specific to the host of the same name as this
 # file (minus extension of course)


### PR DESCRIPTION
Add missing modelines to assist vscode with determining desired syntax settings.