### PR TITLE
Reduce default test inventory, use current LTS

### DIFF
--- a/inventories/testing/host_vars/ansible-centos-1.yml
+++ b/inventories/testing/host_vars/ansible-centos-1.yml
@@ -11,4 +11,10 @@
 # This file is for variables specific to the host of the same name as this
 # file (minus extension of course)
 
+
+# Defines what container image is used
+# See https://images.linuxcontainers.org/ for supported options
+# Specify using 'distribution/release/architecture' format
+lxd_containers_source_alias: "centos/7/amd64"
+
 ...

--- a/inventories/testing/host_vars/ansible-centos-2.yml
+++ b/inventories/testing/host_vars/ansible-centos-2.yml
@@ -11,4 +11,10 @@
 # This file is for variables specific to the host of the same name as this
 # file (minus extension of course)
 
+
+# Defines what container image is used
+# See https://images.linuxcontainers.org/ for supported options
+# Specify using 'distribution/release/architecture' format
+lxd_containers_source_alias: "centos/6/amd64"
+
 ...

--- a/inventories/testing/host_vars/ansible-ubuntu-1.yml
+++ b/inventories/testing/host_vars/ansible-ubuntu-1.yml
@@ -11,4 +11,10 @@
 # This file is for variables specific to the host of the same name as this
 # file (minus extension of course)
 
+
+# Defines what container image is used
+# See https://images.linuxcontainers.org/ for supported options
+# Specify using 'distribution/release/architecture' format
+lxd_containers_source_alias: "ubuntu/bionic/amd64"
+
 ...

--- a/inventories/testing/host_vars/ansible-ubuntu-2.yml
+++ b/inventories/testing/host_vars/ansible-ubuntu-2.yml
@@ -11,4 +11,10 @@
 # This file is for variables specific to the host of the same name as this
 # file (minus extension of course)
 
+
+# Defines what container image is used
+# See https://images.linuxcontainers.org/ for supported options
+# Specify using 'distribution/release/architecture' format
+lxd_containers_source_alias: "ubuntu/xenial/amd64"
+
 ...

--- a/inventories/testing/hosts
+++ b/inventories/testing/hosts
@@ -2,26 +2,39 @@
 # -*- mode: ini; indent-tabs-mode: nil; tab-width: 4 -*-
 # code: language=ini insertSpaces=true tabSize=4
 
-# Inventory file for Ansible testing purposes
+# https://github.com/atc0005/ansible-playbook-lxd-testenv
+# https://github.com/atc0005/ansible-role-lxd-testenv
 
-# Hosts HAVE to be included in one of the OS groups in order to be
+# "Default" inventory file for Ansible testing purposes.
+
+# Purpose: Reduced set of containers that attempts to balance test environment
+# build-up and tear-down speed with common distro versions that are commonly
+# found in production environments. See 'hosts-small' for an even smaller set
+# of containers and 'hosts-large' for an extended host inventory to test
+# against.
+
+# NOTE: Hosts HAVE to be included in one of the OS groups in order to be
 # spun up as a LXD container.
 
 [centos]
 
+# CentOS 7 (by way of host_vars/ansible-centos-1.yml)
 ansible-centos-1
+
+# CentOS 6 (by way of host_vars/ansible-centos-2.yml)
 ansible-centos-2
-ansible-centos-3
-ansible-centos-4
-ansible-centos-5
+
 
 [ubuntu]
 
+# Ubuntu 18.04 (by way of host_vars/ansible-ubuntu-1.yml)
 ansible-ubuntu-1
+
+# Ubuntu 16.04 (by way of host_vars/ansible-ubuntu-2.yml)
 ansible-ubuntu-2
-ansible-ubuntu-3
-ansible-ubuntu-4
-ansible-ubuntu-5
+
+# Ubuntu 18.04 + Docker
+#   if enabled, by way of host_vars/ansible-ubuntu-docker.yml and docker role
 ansible-ubuntu-docker
 
 [docker-hosts:children]
@@ -30,28 +43,6 @@ lxd-docker-containers
 [lxd-docker-containers]
 ansible-ubuntu-docker
 
-[tier1]
-ansible-centos-1
-ansible-ubuntu-1
-
-[tier2]
-ansible-centos-2
-ansible-ubuntu-2
-
-[tier3]
-ansible-centos-3
-ansible-ubuntu-3
-
-[tier4]
-ansible-centos-4
-ansible-ubuntu-4
-
-[tier5]
-ansible-centos-5
-ansible-ubuntu-5
-
-#[lxd_hosts]
-#localhost
 
 [lxd-all-containers:children]
 ubuntu


### PR DESCRIPTION
- Reduce overall number of containers created
- Use current LTS Ubuntu and CentOS imgs + one version back

This gives us 4 current LTS images + one Docker container for testing purposes. This drops the overall container count from 11 to 5.

fixes #27