### PR TITLE
Add "large" and "small" inventory list options

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,35 @@
 *Small suite of playbooks intended to help quickly spin up a test environment
 for other playbook work.*
 
+## Table of Contents
+
+- [Ansible Playbooks: lxd-testenv](#ansible-playbooks-lxd-testenv)
+  - [Table of Contents](#table-of-contents)
+  - [Overview](#overview)
+  - [Limitations](#limitations)
+    - [Linux Distributions](#linux-distributions)
+    - [Docker storage driver](#docker-storage-driver)
+  - [Prerequisites](#prerequisites)
+    - [Inventory](#inventory)
+    - [LXD packages](#lxd-packages)
+    - [LXD configuration](#lxd-configuration)
+      - [TL;DR](#tldr)
+      - [Networking: NAT bridge](#networking-nat-bridge)
+      - [Networking: External bridge](#networking-external-bridge)
+  - [Usage](#usage)
+    - [Install roles](#install-roles)
+    - [Customize playbook variables](#customize-playbook-variables)
+    - [Create new test environment](#create-new-test-environment)
+      - [Default host list](#default-host-list)
+      - [Small host list](#small-host-list)
+      - [Large host list](#large-host-list)
+    - [Teardown test environment](#teardown-test-environment)
+  - [References](#references)
+    - [External](#external)
+      - [General](#general)
+      - [LXD Network configuration](#lxd-network-configuration)
+    - [Related repos](#related-repos)
+
 ## Overview
 
 | Name                       | Purpose (short)                                                      | Documentation                            |
@@ -160,10 +189,22 @@ additional information for each supported option.
 
 ### Create new test environment
 
+#### Default host list
+
 The following steps will prep the host to run LXD containers and then proceed
-to spin up several CentOS and Ubuntu containers:
+to spin up a moderate number of CentOS and Ubuntu containers:
 
 - `ansible-playbook -i inventories/testing site.yml -K`
+
+Breakdown of containers created:
+
+- 5 containers
+  - 1 Ubuntu container explicitly set to the latest LTS release
+  - 1 Ubuntu container explicitly set to the prior LTS release
+  - 1 "Docker" container with the latest Ubuntu LTS release + Docker
+    configuration
+  - 1 CentOS container explicitly set to the latest LTS release
+  - 1 CentOS container explicitly set to the prior LTS release
 
 Note: By default, at least one additional container will be spun up as a
 Docker Host for testing Docker related playbooks. To disable this behavior,
@@ -178,6 +219,43 @@ See these docs for more information:
 
 See [lxd-timing](docs/lxd-timing.md) for *very* rough estimates on the time
 needed to spinup/teardown a test environment.
+
+In addition to the standard set of containers, reduced and extended lists of
+containers are also available depending on your testing needs. See those
+sections for details.
+
+#### Small host list
+
+Quick example:
+
+- `ansible-playbook -i inventories/testing/hosts-small site.yml -K`
+
+Breakdown of containers created:
+
+- 2 containers
+  - 1 "normal" Ubuntu container explicitly set to the latest LTS release
+  - 1 CentOS container explicitly set to the latest LTS release
+  - 0 Ubuntu containers with Docker configuration
+
+#### Large host list
+
+Quick example:
+
+- `ansible-playbook -i inventories/testing/hosts-large site.yml -K`
+
+Breakdown of containers created:
+
+- 11 containers
+  - 1 Ubuntu container explicitly set to the latest LTS release
+  - 1 Ubuntu container explicitly set to the prior LTS release
+  - 1 "Docker" container with the latest Ubuntu LTS release + Docker
+    configuration
+  - 2 Ubuntu containers set to use whatever
+    `inventories/testing/group_vars/ubuntu.yml` is configured with
+  - 1 CentOS container explicitly set to the latest LTS release
+  - 1 CentOS container explicitly set to the prior LTS release
+  - 2 CentOS containers set to use whatever
+    `inventories/testing/group_vars/centos.yml` is configured with
 
 ### Teardown test environment
 

--- a/inventories/testing/hosts-large
+++ b/inventories/testing/hosts-large
@@ -1,0 +1,72 @@
+# vim: ts=4:sw=4:et:ft=ini
+# -*- mode: ini; indent-tabs-mode: nil; tab-width: 4 -*-
+# code: language=ini insertSpaces=true tabSize=4
+
+# https://github.com/atc0005/ansible-playbook-lxd-testenv
+# https://github.com/atc0005/ansible-role-lxd-testenv
+
+# Purpose: Larger set of containers for extended testing purposes.
+
+# See 'hosts-small' for a small set of containers that reflect that latest LTS
+# releases for distros in our production fleet.
+
+# See 'hosts' for a slightly smaller number of containers that reflect current
+# LTS releases + one release back that is still supported by the vendor.
+
+# NOTE: Hosts HAVE to be included in one of the OS groups in order to be
+# spun up as a LXD container.
+
+[centos]
+
+# Default distro release version is set via alias within group_vars/*.yml files
+# Host-specific distro choice set within host_vars/*.yml files
+ansible-centos-1
+ansible-centos-2
+ansible-centos-3
+ansible-centos-4
+ansible-centos-5
+
+[ubuntu]
+
+# Default distro release version is set via alias within group_vars/*.yml files
+# Host-specific distro choice set within host_vars/*.yml files
+ansible-ubuntu-1
+ansible-ubuntu-2
+ansible-ubuntu-3
+ansible-ubuntu-4
+ansible-ubuntu-5
+ansible-ubuntu-docker
+
+[docker-hosts:children]
+lxd-docker-containers
+
+[lxd-docker-containers]
+ansible-ubuntu-docker
+
+[tier1]
+ansible-centos-1
+ansible-ubuntu-1
+
+[tier2]
+ansible-centos-2
+ansible-ubuntu-2
+
+[tier3]
+ansible-centos-3
+ansible-ubuntu-3
+
+[tier4]
+ansible-centos-4
+ansible-ubuntu-4
+
+[tier5]
+ansible-centos-5
+ansible-ubuntu-5
+
+#[lxd_hosts]
+#localhost
+
+[lxd-all-containers:children]
+ubuntu
+centos
+lxd-docker-containers

--- a/inventories/testing/hosts-small
+++ b/inventories/testing/hosts-small
@@ -1,0 +1,34 @@
+# vim: ts=4:sw=4:et:ft=ini
+# -*- mode: ini; indent-tabs-mode: nil; tab-width: 4 -*-
+# code: language=ini insertSpaces=true tabSize=4
+
+# https://github.com/atc0005/ansible-playbook-lxd-testenv
+# https://github.com/atc0005/ansible-role-lxd-testenv
+
+
+# "Small" inventory file for Ansible testing purposes.
+#
+# This inventory file intentionally has a smaller list of containers than the
+# standard inventory file in order to maximize test environment build-up and
+# tear-down speed.
+#
+
+# Hosts HAVE to be included in one of the OS groups in order to be
+# spun up as a LXD container.
+
+[centos]
+
+# CentOS 7 (by way of host_vars/ansible-centos-1.yml)
+ansible-centos-1
+
+
+[ubuntu]
+
+# Ubuntu 18.04 (by way of host_vars/ansible-ubuntu-1.yml)
+ansible-ubuntu-1
+
+
+[lxd-all-containers:children]
+ubuntu
+centos
+


### PR DESCRIPTION
Balance out the reduced host list that is now used by default with options to go even smaller or back to the way it was before the reduction.

- refs #27 
- fixes #29
