### PR TITLE
Remove stray chars, update default example

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ additional information for each supported option.
 The following steps will prep the host to run LXD containers and then proceed
 to spin up a moderate number of CentOS and Ubuntu containers:
 
-- `ansible-playbook -i inventories/testing site.yml -K`
+- `ansible-playbook -i inventories/testing/hosts site.yml -K`
 
 Breakdown of containers created:
 
@@ -266,8 +266,6 @@ using the largest list for teardown will ensure that an attempt is made to
 remove them all.
 
 - `ansible-playbook -i inventories/testing/hosts-large lxd-remove.yml -K`
-
-####
 
 See [this doc](docs/lxd-remove.md) for more information.
 


### PR DESCRIPTION
README updates:

- Pruned start of new section that was never used
- Update "default" example to explicitly reference `hosts` file, otherwise all hosts file in this location are merged instead of the intended "default" being used.
