### PR TITLE
Update lxd-testenv role to v1.2.2

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -10,7 +10,7 @@
 
 - name: "atc0005.lxd-testenv"
   src: "https://github.com/atc0005/ansible-role-lxd-testenv.git"
-  version: "v1.2.1"
+  version: "v1.2.2"
 
 ...
 


### PR DESCRIPTION
Pull in v1.2.2 to resolve unintentional race condition caused by not restricting key pair generation.

refs atc0005/ansible-role-lxd-testenv#43