### PR TITLE
Explicitly increase fact gathering timeout value

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -10,3 +10,9 @@
 # Enable per-play, per-role and final summary of timing statistics
 # https://docs.ansible.com/ansible/latest/plugins/callback.html
 callback_whitelist = profile_tasks, profile_roles, timer
+
+# CentOS 7 seems to be particularly affected by TimeoutError exceptions
+# when performing fact gathering. Attempt to work around that by setting
+# explicit +20s increase in timeout value to give slower systems time
+# to finish gathering information before giving up.
+gather_timeout = 30


### PR DESCRIPTION
This should help with slower systems that are unable to finish fact gathering work within the default 10s.

fixes #42