### PR TITLE
Include python-apt pkg with initial Python install

### DIFF
--- a/inventories/testing/group_vars/ubuntu.yml
+++ b/inventories/testing/group_vars/ubuntu.yml
@@ -15,7 +15,7 @@ lxd_containers_source_alias: "ubuntu/xenial/amd64"
 
 # Distro-specific command needed to install Python 2. Python is needed on the
 # host systems in order to provide access to additional modules.
-python_install_command: "apt-get update && apt-get install -y python"
+python_install_command: "apt-get update && apt-get install -y python python-apt"
 
 # The service name used to start/stop or enable/disable OpenSSH.
 # Ubuntu 14.04: 'ssh'


### PR DESCRIPTION
This resolves the warning that this Ansible dependency is not present in later task steps.

Note: It's been long enough since I worked with this playbook that I no longer recall why I am duplicating the default settings included in the `ansible-role-lxd-testenv` role for Ubuntu systems. I have to assume I did so in an effort to illustrate that the command could be overridden with group-specific settings.

- fixes GH-48
- refs atc0005/ansible-role-lxd-testenv#50